### PR TITLE
Cutlistoptimizer

### DIFF
--- a/CSV-BOM.manifest
+++ b/CSV-BOM.manifest
@@ -7,7 +7,7 @@
 		"":	"Generates BOM output in CSV format. Several options are provided."
 	},
 	"version":	"rel-1-0-0",
-	"runOnStartup":	true,
+	"runOnStartup": false,
 	"supportedOS":	"windows|mac",
-	"editEnabled":	false
+	"editEnabled":	true
 }

--- a/CSV-BOM.manifest
+++ b/CSV-BOM.manifest
@@ -6,7 +6,7 @@
 	"description":	{
 		"":	"Generates BOM output in CSV format. Several options are provided."
 	},
-	"version":	"rel-1-0-0",
+	"version":	"rel-1-1-0",
 	"runOnStartup": false,
 	"supportedOS":	"windows|mac",
 	"editEnabled":	true

--- a/CSV-BOM.py
+++ b/CSV-BOM.py
@@ -205,31 +205,48 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 				csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], item["volume"]) + '",'
 			if prefs["incBoundDims"]:
 				dim = 0
+				footInchDispFormat = app.preferences.unitAndValuePreferences.footAndInchDisplayFormat
+				
 				for k in item["boundingBox"]:
 					dim += item["boundingBox"][k]
 				if dim > 0:
-					dimX = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["x"], defaultUnit, False))
-					dimY = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["y"], defaultUnit, False))
-					dimZ = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False))
-					if prefs["sortDims"]:
-						dimSorted = sorted([dimX, dimY, dimZ])
-						bbZ = "{0:.3f}".format(dimSorted[0])
-						bbX = "{0:.3f}".format(dimSorted[1])
-						bbY = "{0:.3f}".format(dimSorted[2])
+					if footInchDispFormat == 0:
+						dimX = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["x"], defaultUnit, False))
+						dimY = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["y"], defaultUnit, False))
+						dimZ = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False))
+						if prefs["sortDims"]:
+							dimSorted = sorted([dimX, dimY, dimZ])
+							bbZ = "{0:.3f}".format(dimSorted[0])
+							bbX = "{0:.3f}".format(dimSorted[1])
+							bbY = "{0:.3f}".format(dimSorted[2])
+						else:
+							bbX = "{0:.3f}".format(dimX)
+							bbY = "{0:.3f}".format(dimY)
+							bbZ = "{0:.3f}".format(dimZ)
+	
+						if prefs["splitDims"]:
+							csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbX) + '",'
+							csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbY) + '",'
+							csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbZ) + '",'
+						else:
+							dims += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbX) + ' x '
+							dims += self.replacePointDelimterOnPref(prefs["useComma"], bbY) + ' x '
+							dims += self.replacePointDelimterOnPref(prefs["useComma"], bbZ)
+							csvStr += dims + '",'
 					else:
-						bbX = "{0:.3f}".format(dimX)
-						bbY = "{0:.3f}".format(dimY)
-						bbZ = "{0:.3f}".format(dimZ)
+						dimX = design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["x"], defaultUnit, False)
+						dimY = design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["y"], defaultUnit, False)
+						dimZ = design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False)
 
-					if prefs["splitDims"]:
-						csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbX) + '",'
-						csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbY) + '",'
-						csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbZ) + '",'
-					else:
-						dims += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbX) + ' x '
-						dims += self.replacePointDelimterOnPref(prefs["useComma"], bbY) + ' x '
-						dims += self.replacePointDelimterOnPref(prefs["useComma"], bbZ)
-						csvStr += dims + '",'
+						if prefs["splitDims"]:
+							csvStr += '"' + dimX + '",'
+							csvStr += '"' + dimY + '",'
+							csvStr += '"' + dimZ + '",'
+						else:
+							dims += '"' + dimX + ' x '
+							dims += dimY + ' x '
+							dims += dimZ
+							csvStr += dims + '",'						
 				else:
 					if prefs["splitDims"]:
 						csvStr += "0" + ','

--- a/CSV-BOM.py
+++ b/CSV-BOM.py
@@ -239,13 +239,13 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 						dimZ = design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False)
 
 						if prefs["splitDims"]:
-							csvStr += '"' + dimX + '",'
-							csvStr += '"' + dimY + '",'
-							csvStr += '"' + dimZ + '",'
+							csvStr += '"' + dimX.replace('"', '""') + '",'
+							csvStr += '"' + dimY.replace('"', '""') + '",'
+							csvStr += '"' + dimZ.replace('"', '""') + '",'
 						else:
-							dims += '"' + dimX + ' x '
-							dims += dimY + ' x '
-							dims += dimZ
+							dims += '"' + dimX.replace('"', '""') + ' x '
+							dims += dimY.replace('"', '""') + ' x '
+							dims += dimZ.replace('"', '""')
 							csvStr += dims + '",'						
 				else:
 					if prefs["splitDims"]:

--- a/CSV-BOM.py
+++ b/CSV-BOM.py
@@ -216,13 +216,13 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 						dimZ = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False))
 						if prefs["sortDims"]:
 							dimSorted = sorted([dimX, dimY, dimZ])
-							bbZ = "{0:.3f}".format(dimSorted[0])
-							bbX = "{0:.3f}".format(dimSorted[1])
-							bbY = "{0:.3f}".format(dimSorted[2])
+							bbZ = "{0:.8f}".format(dimSorted[0])
+							bbX = "{0:.8f}".format(dimSorted[1])
+							bbY = "{0:.8f}".format(dimSorted[2])
 						else:
-							bbX = "{0:.3f}".format(dimX)
-							bbY = "{0:.3f}".format(dimY)
-							bbZ = "{0:.3f}".format(dimZ)
+							bbX = "{0:.8f}".format(dimX)
+							bbY = "{0:.8f}".format(dimY)
+							bbZ = "{0:.8f}".format(dimZ)
 	
 						if prefs["splitDims"]:
 							csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbX) + '",'
@@ -299,8 +299,8 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 					dims = [dimZ, dimX, dimY]
 
 				partStr = ' '  # leading space
-				partStr += self.replacePointDelimterOnPref(prefs["useComma"], "{0:.3f}".format(dims[1])).ljust(9)  # width
-				partStr += self.replacePointDelimterOnPref(prefs["useComma"], "{0:.3f}".format(dims[2])).ljust(7)  # length
+				partStr += self.replacePointDelimterOnPref(prefs["useComma"], "{0:.8f}".format(dims[1])).ljust(9)  # width
+				partStr += self.replacePointDelimterOnPref(prefs["useComma"], "{0:.8f}".format(dims[2])).ljust(7)  # length
 
 				partStr += name
 				partStr += ' (thickness: ' + self.replacePointDelimterOnPref(prefs["useComma"], "{0:.3f}".format(dims[0])) + defaultUnit + ')'

--- a/CSV-BOM.py
+++ b/CSV-BOM.py
@@ -172,14 +172,14 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 	def collectData(self, design, bom, prefs):
 		csvStr = ''
 		defaultUnit = design.fusionUnitsManager.defaultLengthUnits
-		csvHeader = ["Part name", "Quantity"]
+		csvHeader = ["Label", "Qty"]
 		if prefs["incVol"]:
 			csvHeader.append("Volume cm^3")
 		if prefs["incBoundDims"]:
 			if prefs["splitDims"]:
-				csvHeader.append("Width " + defaultUnit)
-				csvHeader.append("Length " + defaultUnit)
-				csvHeader.append("Height " + defaultUnit)
+				csvHeader.append("Length")
+				csvHeader.append("Width")
+				csvHeader.append("Height")
 			else:
 				csvHeader.append("Dimension " + defaultUnit)
 		if prefs["incArea"]:
@@ -225,8 +225,8 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 							bbZ = "{0:.8f}".format(dimZ)
 	
 						if prefs["splitDims"]:
-							csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbX) + '",'
 							csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbY) + '",'
+							csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbX) + '",'
 							csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbZ) + '",'
 						else:
 							dims += '"' + self.replacePointDelimterOnPref(prefs["useComma"], bbX) + ' x '
@@ -239,8 +239,8 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 						dimZ = design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False)
 
 						if prefs["splitDims"]:
-							csvStr += '"' + dimX.replace('"', '""') + '",'
 							csvStr += '"' + dimY.replace('"', '""') + '",'
+							csvStr += '"' + dimX.replace('"', '""') + '",'
 							csvStr += '"' + dimZ.replace('"', '""') + '",'
 						else:
 							dims += '"' + dimX.replace('"', '""') + ' x '
@@ -299,8 +299,8 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 					dims = [dimZ, dimX, dimY]
 
 				partStr = ' '  # leading space
-				partStr += self.replacePointDelimterOnPref(prefs["useComma"], "{0:.8f}".format(dims[1])).ljust(9)  # width
 				partStr += self.replacePointDelimterOnPref(prefs["useComma"], "{0:.8f}".format(dims[2])).ljust(7)  # length
+				partStr += self.replacePointDelimterOnPref(prefs["useComma"], "{0:.8f}".format(dims[1])).ljust(9)  # width
 
 				partStr += name
 				partStr += ' (thickness: ' + self.replacePointDelimterOnPref(prefs["useComma"], "{0:.3f}".format(dims[0])) + defaultUnit + ')'

--- a/CSV-BOM.py
+++ b/CSV-BOM.py
@@ -157,6 +157,8 @@ class BOMCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
 		cmd.inputChanged.add(onInputChanged)
 		handlers.append(onInputChanged)
 
+def myround(x, base=5):
+    return base * round(x/base)
 
 # Event handler for the execute event.
 class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
@@ -215,6 +217,9 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 						dimX = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["x"], defaultUnit, False))
 						dimY = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["y"], defaultUnit, False))
 						dimZ = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False))
+						dimY = myround(dimY, 1/128)
+						dimX = myround(dimX, 1/128)
+						dimZ = myround(dimZ, 1/128)
 						if prefs["sortDims"]:
 							dimSorted = sorted([dimX, dimY, dimZ])
 							bbZ = "{0:.8f}".format(dimSorted[0])
@@ -238,6 +243,9 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 						dimX = design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["x"], defaultUnit, False)
 						dimY = design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["y"], defaultUnit, False)
 						dimZ = design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False)
+						dimY = myround(dimY, 1/128)
+						dimX = myround(dimX, 1/128)
+						dimZ = myround(dimZ, 1/128)
 
 						if prefs["splitDims"]:
 							csvStr += '"' + dimY.replace('"', '""') + '",'
@@ -295,6 +303,9 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 				dimX = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["x"], defaultUnit, False))
 				dimY = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["y"], defaultUnit, False))
 				dimZ = float(design.fusionUnitsManager.formatInternalValue(item["boundingBox"]["z"], defaultUnit, False))
+				dimY = myround(dimY, 1/128)
+				dimX = myround(dimX, 1/128)
+				dimZ = myround(dimZ, 1/128)
 
 				if prefs["sortDims"]:
 					dims = sorted([dimX, dimY, dimZ])

--- a/CSV-BOM.py
+++ b/CSV-BOM.py
@@ -172,7 +172,7 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 	def collectData(self, design, bom, prefs):
 		csvStr = ''
 		defaultUnit = design.fusionUnitsManager.defaultLengthUnits
-		csvHeader = ["Label", "Qty"]
+		csvHeader = []
 		if prefs["incVol"]:
 			csvHeader.append("Volume cm^3")
 		if prefs["incBoundDims"]:
@@ -182,14 +182,16 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 				csvHeader.append("Height")
 			else:
 				csvHeader.append("Dimension " + defaultUnit)
+		csvHeader.append("Qty")
+		if prefs["incMaterial"]:
+			csvHeader.append("Material")
+		csvHeader.append("Label")
 		if prefs["incArea"]:
 			csvHeader.append("Area cm^2")
 		if prefs["incMass"]:
 			csvHeader.append("Mass kg")
 		if prefs["incDensity"]:
 			csvHeader.append("Density kg/cm^2")
-		if prefs["incMaterial"]:
-			csvHeader.append("Material")
 		if prefs["incDesc"]:
 			csvHeader.append("Description")
 		for k in csvHeader:
@@ -200,7 +202,6 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 			name = self.filterFusionCompNameInserts(item["name"])
 			if prefs["ignoreUnderscorePrefComp"] is False and prefs["underscorePrefixStrip"] is True and name[0] == '_':
 				name = name[1:]
-			csvStr += '"' + name + '","' + self.replacePointDelimterOnPref(prefs["useComma"], item["instances"]) + '",'
 			if prefs["incVol"]:
 				csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], item["volume"]) + '",'
 			if prefs["incBoundDims"]:
@@ -254,14 +255,16 @@ class BOMCommandExecuteHandler(adsk.core.CommandEventHandler):
 						csvStr += "0" + ','
 					else:
 						csvStr += "0" + ','
+			csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], item["instances"]) + '",'
+			if prefs["incMaterial"]:
+				csvStr += '"' + item["material"] + '",'
+			csvStr += '"' + name + '","'
 			if prefs["incArea"]:
 				csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], "{0:.2f}".format(item["area"])) + '",'
 			if prefs["incMass"]:
 				csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], "{0:.5f}".format(item["mass"])) + '",'
 			if prefs["incDensity"]:
 				csvStr += '"' + self.replacePointDelimterOnPref(prefs["useComma"], "{0:.5f}".format(item["density"])) + '",'
-			if prefs["incMaterial"]:
-				csvStr += '"' + item["material"] + '",'
 			if prefs["incDesc"]:
 				csvStr += '"' + item["desc"] + '",'
 			csvStr += '\n'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# CSV-BOM
+# CSV-BOM-WOODWORKING
+
+The CSV-BOM-WOODWORKING is a fork of the original CSV-BOM add-in for Fusion 360 with a focus on generating a BOM csv file compatible, "out of the box", with cutlist optimizer (https://www.cutlistoptimizer.com/). It adds the following:
+- Orders the CSV columns to work with cutlist optimimzer.
+- Changes columns headers to work with custlist optimizer.
+- Increase measurements precisions to 8 digits in order to allow to have a precision up to 1/128 of an inch.
+- round measurements to 1/128 of an inch. A precision meaningful for woodworkers.
+
 Creates a bill of material and cut lists from the browser components tree in Autodesk Fusion360.
 
 ## General Usage Instructions


### PR DESCRIPTION
Modifying original CSV-BOM to add to order CSV columns to be compliant with cutlist optimizer, increase the precision of the measurements to 8 digits and round the measurements to 1/128.